### PR TITLE
Update translate_func.py

### DIFF
--- a/trans/translate_func.py
+++ b/trans/translate_func.py
@@ -20,6 +20,7 @@ import requests   # pip intasll requests
 import execjs  # 安装指令：pip install PyExecJS
 import random
 import hashlib
+import re
 
 
 

--- a/trans/translate_func.py
+++ b/trans/translate_func.py
@@ -156,5 +156,6 @@ def baidu_translate(content):
     j = requests.get('http://api.fanyi.baidu.com/api/trans/vip/translate', head)
     print(j.json())
     res = j.json()['trans_result'][0]['dst']
+    res = re.compile('[\\x00-\\x08\\x0b-\\x0c\\x0e-\\x1f]').sub(' ', res)
     print(res)
-    return str(res)
+    return res


### PR DESCRIPTION
1、百度翻译API返回的 res本身就是 str 类型，不需要类型转换
2、如果提取的内容中含有乱码，比如（\x13）这种，是无法正常写入文档的，需要过滤